### PR TITLE
Log biography text during event join verification

### DIFF
--- a/services/eventService.js
+++ b/services/eventService.js
@@ -453,6 +453,10 @@ export class EventService {
         return;
       }
 
+      this.logger.info(
+        `[EVENT] Biografía de ${interaction.user.tag} (${interaction.user.id}): ${bioText || '<vacía>'}`
+      );
+
       if (!bioText.includes(requiredBioLink)) {
         const message = `No puedes unirte al evento. Asegúrate de que tu biografía incluya ${requiredBioLink}.`;
         this.logger.info(


### PR DESCRIPTION
## Summary
- log the full biography text when verifying a user during the event join flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccdd92b0e48326ba6cac30f25f2bb7