### PR TITLE
Add admin database tools and command registration safeguards

### DIFF
--- a/features/admin/index.js
+++ b/features/admin/index.js
@@ -1,0 +1,10 @@
+import { COMMAND_PREFIX } from '../../config/constants.js';
+import { guard } from '../../utils/guard.js';
+import { handleDbCommand } from './logic.js';
+
+export const adminFeature = {
+  commands: [
+    { type: 'slash', name: 'db', execute: guard(handleDbCommand, { cooldownMs: 10_000 }) },
+    { type: 'prefix', name: `${COMMAND_PREFIX}db`, execute: guard(handleDbCommand, { cooldownMs: 10_000 }) },
+  ],
+};

--- a/features/admin/logic.js
+++ b/features/admin/logic.js
@@ -1,0 +1,268 @@
+import dayjs from 'dayjs';
+import { ENTITY_CONFIG, DEFAULT_PAGE_SIZE, deleteRecord, isSupportedEntity, listRecords, searchRecords } from '../../services/admin.repo.js';
+import { parseUser } from '../../utils/helpers.js';
+import { logger } from '../../utils/logger.js';
+import {
+  buildDbDeleteNotFound,
+  buildDbDeleteSuccess,
+  buildDbErrorEmbed,
+  buildDbListEmbed,
+  buildDbPageOutOfRangeEmbed,
+  buildDbSearchEmbed,
+  buildDbUsageEmbed,
+} from './ui.js';
+
+function isSlashCommand(ctx) {
+  return typeof ctx.isChatInputCommand === 'function' && ctx.isChatInputCommand();
+}
+
+async function sendReply(ctx, payload, { ephemeral } = {}) {
+  const defaultEphemeral = isSlashCommand(ctx);
+  if ('reply' in ctx && typeof ctx.reply === 'function') {
+    return ctx.reply({ ...payload, ephemeral: ephemeral ?? defaultEphemeral });
+  }
+  if ('followUp' in ctx && typeof ctx.followUp === 'function') {
+    return ctx.followUp({ ...payload, ephemeral: ephemeral ?? defaultEphemeral });
+  }
+  if ('channel' in ctx && typeof ctx.channel?.send === 'function') {
+    if (typeof ctx.reply === 'function') {
+      return ctx.reply(payload);
+    }
+    return ctx.channel.send(payload);
+  }
+  throw new Error('Contexto no soportado para respuesta');
+}
+
+function formatDate(value) {
+  if (!value) return 'N/A';
+  return dayjs(value).format('DD/MM/YYYY HH:mm');
+}
+
+function truncate(text, max = 100) {
+  if (!text) return 'Sin información';
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}
+
+const ENTITY_FORMATTERS = {
+  users: (row) =>
+    `• <@${row.id}> — Roblox: ${row.roblox_id ?? 'N/A'} — Creado: ${formatDate(row.created_at)}`,
+  middlemen: (row) => {
+    const ratingCount = Number(row.rating_count ?? 0);
+    const ratingSum = Number(row.rating_sum ?? 0);
+    const ratingLabel = ratingCount > 0 ? `${(ratingSum / ratingCount).toFixed(2)}⭐ (${ratingCount})` : 'Sin reseñas';
+    return `• <@${row.discord_user_id}> — Roblox: ${row.roblox_username ?? 'N/A'} — Vouches: ${row.vouches_count ?? 0} — Rating: ${ratingLabel}`;
+  },
+  warns: (row) => {
+    const moderator = row.moderator_id ? `<@${row.moderator_id}>` : 'N/A';
+    const reason = truncate(row.reason ?? 'Sin motivo');
+    return `• #${row.id} — Usuario: <@${row.user_id}> — Severidad: ${row.severity ?? 'sin dato'} — Moderador: ${moderator} — ${formatDate(row.created_at)} — Motivo: ${reason}`;
+  },
+  tickets: (row) => {
+    const closed = row.closed_at ? ` — Cerrado: ${formatDate(row.closed_at)}` : '';
+    const owner = row.owner_id ? `<@${row.owner_id}>` : 'N/A';
+    const channel = row.channel_id ? `<#${row.channel_id}>` : 'N/A';
+    return `• #${row.id} — Tipo: ${row.type} — Estado: ${row.status} — Dueño: ${owner} — Canal: ${channel} — Creado: ${formatDate(row.created_at)}${closed}`;
+  },
+};
+
+function formatEntries(entity, rows) {
+  const formatter = ENTITY_FORMATTERS[entity];
+  if (!formatter) {
+    return rows.map((row) => `• ${JSON.stringify(row)}`);
+  }
+  return rows.map((row) => formatter(row));
+}
+
+function normalizeEntity(value) {
+  return value?.toLowerCase?.() ?? '';
+}
+
+function normalizeIdentifier(entity, value) {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  if (entity === 'users' || entity === 'middlemen') {
+    return parseUser(trimmed) ?? trimmed;
+  }
+  return trimmed;
+}
+
+function computePageCount(total, pageSize = DEFAULT_PAGE_SIZE) {
+  if (!total) return 0;
+  return Math.ceil(total / pageSize);
+}
+
+function parseSlashInput(interaction) {
+  if (!isSlashCommand(interaction)) {
+    return { ok: false };
+  }
+  const sub = interaction.options.getSubcommand(false);
+  const entity = normalizeEntity(interaction.options.getString('entidad'));
+  if (!sub || !entity) {
+    return { ok: false };
+  }
+  switch (sub) {
+    case 'list': {
+      const page = interaction.options.getInteger('pagina') ?? 1;
+      return { ok: true, action: 'list', entity, page };
+    }
+    case 'search': {
+      const query = interaction.options.getString('texto', true);
+      const page = interaction.options.getInteger('pagina') ?? 1;
+      return { ok: true, action: 'search', entity, query, page };
+    }
+    case 'delete': {
+      const identifier = interaction.options.getString('identificador', true);
+      return { ok: true, action: 'delete', entity, identifier };
+    }
+    default:
+      return { ok: false };
+  }
+}
+
+function parsePrefixInput(message) {
+  const parts = message.content.trim().split(/\s+/);
+  parts.shift();
+  const [actionRaw, entityRaw, ...rest] = parts;
+  const action = actionRaw?.toLowerCase?.();
+  const entity = normalizeEntity(entityRaw);
+  if (!action || !entity) {
+    return { ok: false };
+  }
+  if (action === 'list') {
+    const pageCandidate = rest[0];
+    const page = pageCandidate && /^\d+$/.test(pageCandidate) ? Number.parseInt(pageCandidate, 10) : 1;
+    return { ok: true, action, entity, page };
+  }
+  if (action === 'search') {
+    if (!rest.length) {
+      return { ok: false };
+    }
+    let page = 1;
+    if (rest.length > 1 && /^\d+$/.test(rest[rest.length - 1])) {
+      page = Number.parseInt(rest.pop(), 10);
+    }
+    const query = rest.join(' ');
+    if (!query) {
+      return { ok: false };
+    }
+    return { ok: true, action, entity, query, page };
+  }
+  if (action === 'delete') {
+    const identifier = rest.join(' ');
+    if (!identifier) {
+      return { ok: false };
+    }
+    return { ok: true, action, entity, identifier };
+  }
+  return { ok: false };
+}
+
+function ensureValidQuery(query) {
+  const sanitized = query.trim();
+  if (sanitized.length < 2) {
+    return { ok: false, error: 'La búsqueda debe tener al menos 2 caracteres.' };
+  }
+  if (sanitized.length > 100) {
+    return { ok: false, error: 'La búsqueda es demasiado larga (máximo 100 caracteres).' };
+  }
+  return { ok: true, value: sanitized };
+}
+
+async function handleList(ctx, { entity, page }) {
+  const config = ENTITY_CONFIG[entity];
+  const result = await listRecords(entity, { page });
+  const pageCount = computePageCount(result.total, result.pageSize);
+  if ((pageCount > 0 && result.page > pageCount) || (pageCount === 0 && result.page > 1)) {
+    const embed = buildDbPageOutOfRangeEmbed({ entityLabel: config.label, page: result.page, pageCount });
+    await sendReply(ctx, embed);
+    return;
+  }
+  const entries = formatEntries(entity, result.rows);
+  const embed = buildDbListEmbed({
+    entityLabel: config.label,
+    page: result.page,
+    pageCount,
+    total: result.total,
+    entries,
+  });
+  await sendReply(ctx, embed);
+  logger.flow('Admin DB list', entity, 'page', result.page, 'executor', ctx.user?.id ?? ctx.author?.id);
+}
+
+async function handleSearch(ctx, { entity, query, page }) {
+  const config = ENTITY_CONFIG[entity];
+  const result = await searchRecords(entity, query, { page });
+  const pageCount = computePageCount(result.total, result.pageSize);
+  if ((pageCount > 0 && result.page > pageCount) || (pageCount === 0 && result.page > 1)) {
+    const embed = buildDbPageOutOfRangeEmbed({ entityLabel: config.label, page: result.page, pageCount });
+    await sendReply(ctx, embed);
+    return;
+  }
+  const entries = formatEntries(entity, result.rows);
+  const embed = buildDbSearchEmbed({
+    entityLabel: config.label,
+    query,
+    page: result.page,
+    pageCount,
+    total: result.total,
+    entries,
+  });
+  await sendReply(ctx, embed);
+  logger.flow('Admin DB search', entity, 'query', query, 'page', result.page, 'executor', ctx.user?.id ?? ctx.author?.id);
+}
+
+async function handleDelete(ctx, { entity, identifier }) {
+  const config = ENTITY_CONFIG[entity];
+  const normalized = normalizeIdentifier(entity, identifier);
+  if (!normalized) {
+    const embed = buildDbErrorEmbed('No se pudo interpretar el identificador indicado.');
+    await sendReply(ctx, embed);
+    return;
+  }
+  const affected = await deleteRecord(entity, normalized);
+  if (affected > 0) {
+    const embed = buildDbDeleteSuccess({ entityLabel: config.label, identifier: normalized });
+    await sendReply(ctx, embed, { ephemeral: true });
+    logger.flow('Admin DB delete', entity, 'id', normalized, 'executor', ctx.user?.id ?? ctx.author?.id);
+    return;
+  }
+  const embed = buildDbDeleteNotFound({ entityLabel: config.label, identifier: normalized });
+  await sendReply(ctx, embed);
+}
+
+export async function handleDbCommand(ctx) {
+  try {
+    const parsed = isSlashCommand(ctx) ? parseSlashInput(ctx) : parsePrefixInput(ctx);
+    if (!parsed.ok) {
+      await sendReply(ctx, buildDbUsageEmbed());
+      return;
+    }
+    if (!isSupportedEntity(parsed.entity)) {
+      await sendReply(ctx, buildDbErrorEmbed('Entidad no soportada. Usa `users`, `middlemen`, `warns` o `tickets`.'));
+      return;
+    }
+    if (parsed.action === 'list') {
+      await handleList(ctx, parsed);
+      return;
+    }
+    if (parsed.action === 'search') {
+      const validation = ensureValidQuery(parsed.query);
+      if (!validation.ok) {
+        await sendReply(ctx, buildDbErrorEmbed(validation.error));
+        return;
+      }
+      await handleSearch(ctx, { ...parsed, query: validation.value });
+      return;
+    }
+    if (parsed.action === 'delete') {
+      await handleDelete(ctx, parsed);
+      return;
+    }
+    await sendReply(ctx, buildDbUsageEmbed());
+  } catch (error) {
+    logger.error('Error ejecutando comando admin DB', error);
+    await sendReply(ctx, buildDbErrorEmbed('Ocurrió un error al procesar el comando. Inténtalo nuevamente.'));
+  }
+}

--- a/features/admin/ui.js
+++ b/features/admin/ui.js
@@ -1,0 +1,71 @@
+import { EmbedBuilder } from 'discord.js';
+import { applyDedosBrand, createDedosAttachment } from '../../utils/branding.js';
+
+function withBrand(embed) {
+  return { embeds: [applyDedosBrand(embed)], files: [createDedosAttachment()] };
+}
+
+export function buildDbUsageEmbed() {
+  const embed = new EmbedBuilder()
+    .setTitle('🛠️ Herramientas administrativas')
+    .setDescription(
+      [
+        'Comandos disponibles:',
+        '• `/db list <entidad> [página]` — Lista registros paginados.',
+        '• `/db search <entidad> <texto>` — Busca coincidencias.',
+        '• `/db delete <entidad> <id>` — Elimina un registro.',
+        '• También puedes usar el prefijo `;db` con los mismos argumentos.',
+        '',
+        'Entidades soportadas: `users`, `middlemen`, `warns`, `tickets`.',
+      ].join('\n')
+    );
+  return withBrand(embed);
+}
+
+export function buildDbListEmbed({ entityLabel, page, pageCount, total, entries }) {
+  const embed = new EmbedBuilder()
+    .setTitle(`📂 ${entityLabel} — página ${page}/${Math.max(pageCount, 1)}`)
+    .setDescription(entries.length ? entries.join('\n') : 'No hay registros para mostrar.')
+    .addFields({ name: 'Total', value: String(total), inline: true });
+  return withBrand(embed);
+}
+
+export function buildDbSearchEmbed({ entityLabel, query, page, pageCount, total, entries }) {
+  const embed = new EmbedBuilder()
+    .setTitle(`🔍 ${entityLabel} — búsqueda: ${query}`)
+    .setDescription(entries.length ? entries.join('\n') : 'No se encontraron coincidencias.')
+    .addFields(
+      { name: 'Resultados', value: String(total), inline: true },
+      { name: 'Página', value: `${page}/${Math.max(pageCount, 1)}`, inline: true }
+    );
+  return withBrand(embed);
+}
+
+export function buildDbDeleteSuccess({ entityLabel, identifier }) {
+  const embed = new EmbedBuilder()
+    .setTitle('✅ Registro eliminado')
+    .setDescription(`Se eliminó el registro **${identifier}** de ${entityLabel.toLowerCase()}.`);
+  return withBrand(embed);
+}
+
+export function buildDbDeleteNotFound({ entityLabel, identifier }) {
+  const embed = new EmbedBuilder()
+    .setTitle('ℹ️ Nada que eliminar')
+    .setDescription(`No se encontró el registro **${identifier}** en ${entityLabel.toLowerCase()}.`);
+  return withBrand(embed);
+}
+
+export function buildDbErrorEmbed(message) {
+  const embed = new EmbedBuilder().setTitle('❌ Error').setDescription(message);
+  return withBrand(embed);
+}
+
+export function buildDbPageOutOfRangeEmbed({ entityLabel, page, pageCount }) {
+  const embed = new EmbedBuilder()
+    .setTitle('⚠️ Página no disponible')
+    .setDescription(
+      `Solo hay ${pageCount} página${pageCount === 1 ? '' : 's'} de ${entityLabel.toLowerCase()}. Intenta con un número menor.`
+    )
+    .addFields({ name: 'Página solicitada', value: String(page), inline: true });
+  return withBrand(embed);
+}

--- a/features/index.js
+++ b/features/index.js
@@ -1,8 +1,19 @@
+import { adminFeature } from './admin/index.js';
 import { middlemanFeature } from './middleman/index.js';
 import { ticketsFeature } from './tickets/index.js';
 import { warnsFeature } from './warns/index.js';
+import { logger } from '../utils/logger.js';
 
-export const FEATURES = [middlemanFeature, ticketsFeature, warnsFeature];
+export const FEATURES = [adminFeature, middlemanFeature, ticketsFeature, warnsFeature];
+
+function registerCommand(map, command, type) {
+  if (map.has(command.name)) {
+    const message = `El comando ${type} "${command.name}" ya está registrado.`;
+    logger.error(message);
+    throw new Error(message);
+  }
+  map.set(command.name, command.execute);
+}
 
 export async function dispatchFeatureInteraction(interaction) {
   for (const feature of FEATURES) {
@@ -19,7 +30,7 @@ export function buildSlashCommandMap() {
   for (const feature of FEATURES) {
     for (const command of feature.commands ?? []) {
       if (command.type === 'slash') {
-        map.set(command.name, command.execute);
+        registerCommand(map, command, 'slash');
       }
     }
   }
@@ -31,7 +42,7 @@ export function buildPrefixCommandMap() {
   for (const feature of FEATURES) {
     for (const command of feature.commands ?? []) {
       if (command.type === 'prefix') {
-        map.set(command.name, command.execute);
+        registerCommand(map, command, 'prefijo');
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "register:commands": "node scripts/register-commands.js"
+    "register:commands": "node scripts/register-commands.js",
+    "clear:commands": "node scripts/clear-commands.js"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/scripts/clear-commands.js
+++ b/scripts/clear-commands.js
@@ -1,0 +1,23 @@
+import 'dotenv/config';
+import { REST, Routes } from 'discord.js';
+
+const rest = new REST({ version: '10' }).setToken(process.env.TOKEN);
+
+async function main() {
+  const clientId = process.env.CLIENT_ID;
+  if (!clientId) {
+    throw new Error('Falta CLIENT_ID en el entorno');
+  }
+  if (process.env.GUILD_ID) {
+    await rest.put(Routes.applicationGuildCommands(clientId, process.env.GUILD_ID), { body: [] });
+    console.log('✅ Comandos eliminados del servidor especificado.');
+    return;
+  }
+  await rest.put(Routes.applicationCommands(clientId), { body: [] });
+  console.log('✅ Comandos globales eliminados.');
+}
+
+main().catch((error) => {
+  console.error('❌ Error eliminando comandos', error);
+  process.exitCode = 1;
+});

--- a/services/admin.repo.js
+++ b/services/admin.repo.js
@@ -1,0 +1,127 @@
+import { pool } from './db.js';
+
+export const DEFAULT_PAGE_SIZE = 10;
+
+export const ENTITY_CONFIG = {
+  users: {
+    table: 'users',
+    label: 'Usuarios',
+    idColumn: 'id',
+    orderBy: 'created_at DESC',
+    select: 'id, roblox_id, created_at',
+    searchColumns: ['id', 'roblox_id'],
+  },
+  middlemen: {
+    table: 'middlemen',
+    label: 'Middlemans',
+    idColumn: 'discord_user_id',
+    orderBy: 'updated_at DESC',
+    select:
+      'discord_user_id, roblox_username, roblox_user_id, vouches_count, rating_sum, rating_count, created_at, updated_at',
+    searchColumns: ['discord_user_id', 'roblox_username', 'roblox_user_id'],
+  },
+  warns: {
+    table: 'warns',
+    label: 'Warns',
+    idColumn: 'id',
+    orderBy: 'created_at DESC',
+    select: 'id, user_id, moderator_id, severity, reason, created_at',
+    searchColumns: ['id', 'user_id', 'moderator_id', 'reason', 'severity'],
+  },
+  tickets: {
+    table: 'tickets',
+    label: 'Tickets',
+    idColumn: 'id',
+    orderBy: 'created_at DESC',
+    select: 'id, owner_id, guild_id, channel_id, type, status, created_at, closed_at',
+    searchColumns: ['id', 'owner_id', 'channel_id', 'type', 'status'],
+  },
+};
+
+function getEntityConfig(entity) {
+  return ENTITY_CONFIG[entity] ?? null;
+}
+
+function sanitizePageSize(pageSize) {
+  const parsed = Number.parseInt(pageSize, 10);
+  if (Number.isNaN(parsed) || parsed < 1) return DEFAULT_PAGE_SIZE;
+  return Math.min(25, parsed);
+}
+
+export function sanitizePage(page) {
+  const parsed = Number.parseInt(page, 10);
+  if (Number.isNaN(parsed) || parsed < 1) return 1;
+  return parsed;
+}
+
+function buildSearchClause(columns, term) {
+  const likeTerm = `%${term}%`;
+  const clauses = columns.map((column) => `CAST(${column} AS CHAR) LIKE ?`);
+  return {
+    clause: clauses.length ? `WHERE ${clauses.join(' OR ')}` : '',
+    params: columns.map(() => likeTerm),
+  };
+}
+
+export function isSupportedEntity(entity) {
+  return Boolean(getEntityConfig(entity));
+}
+
+export async function listRecords(entity, { page = 1, pageSize = DEFAULT_PAGE_SIZE } = {}) {
+  const config = getEntityConfig(entity);
+  if (!config) {
+    throw new Error(`Entidad no soportada: ${entity}`);
+  }
+  const safePage = sanitizePage(page);
+  const safePageSize = sanitizePageSize(pageSize);
+  const offset = (safePage - 1) * safePageSize;
+  const [rows] = await pool.query(
+    `SELECT ${config.select}
+       FROM ${config.table}
+       ORDER BY ${config.orderBy}
+       LIMIT ? OFFSET ?`,
+    [safePageSize, offset]
+  );
+  const [[{ total }]] = await pool.query(`SELECT COUNT(*) AS total FROM ${config.table}`);
+  return { rows, total, page: safePage, pageSize: safePageSize };
+}
+
+export async function searchRecords(entity, term, { page = 1, pageSize = DEFAULT_PAGE_SIZE } = {}) {
+  const config = getEntityConfig(entity);
+  if (!config) {
+    throw new Error(`Entidad no soportada: ${entity}`);
+  }
+  const sanitizedTerm = term.trim();
+  if (!sanitizedTerm) {
+    return { rows: [], total: 0, page: 1, pageSize: sanitizePageSize(pageSize) };
+  }
+  const safePage = sanitizePage(page);
+  const safePageSize = sanitizePageSize(pageSize);
+  const offset = (safePage - 1) * safePageSize;
+  const { clause, params } = buildSearchClause(config.searchColumns, sanitizedTerm);
+  const [rows] = await pool.query(
+    `SELECT ${config.select}
+       FROM ${config.table}
+       ${clause}
+       ORDER BY ${config.orderBy}
+       LIMIT ? OFFSET ?`,
+    [...params, safePageSize, offset]
+  );
+  const [[{ total }]] = await pool.query(
+    `SELECT COUNT(*) AS total FROM ${config.table} ${clause}`,
+    params
+  );
+  return { rows, total, page: safePage, pageSize: safePageSize };
+}
+
+export async function deleteRecord(entity, identifier) {
+  const config = getEntityConfig(entity);
+  if (!config) {
+    throw new Error(`Entidad no soportada: ${entity}`);
+  }
+  const [result] = await pool.query(
+    `DELETE FROM ${config.table} WHERE ${config.idColumn} = ? LIMIT 1`,
+    [identifier]
+  );
+  return result.affectedRows;
+}


### PR DESCRIPTION
## Summary
- add an admin feature that exposes paginated list, search, and delete database commands to slash and prefix interfaces with cooldowns
- prevent duplicate command registrations and ensure middleman add checks for prior registration before updating data
- extend command scripts with DB command definitions, uniqueness checks, and a utility to clear all registered commands

## Testing
- node --check scripts/register-commands.js
- node --check scripts/clear-commands.js
- node --check features/admin/logic.js

------
https://chatgpt.com/codex/tasks/task_e_68d328515d9c8326a9cb4604ec815d24