### PR TITLE
Fix overwrites for middleman trade lock

### DIFF
--- a/features/middleman/logic.js
+++ b/features/middleman/logic.js
@@ -1,5 +1,6 @@
 import {
   ChannelType,
+  OverwriteType,
   PermissionFlagsBits,
 } from 'discord.js';
 import { CONFIG } from '../../config/config.js';
@@ -169,14 +170,19 @@ function resolveParticipantIds(ticket, participants) {
 }
 
 async function updateSendPermission(channel, userId, value) {
-  if (!userId) {
+  const targetId = normalizeSnowflake(userId);
+  if (!targetId) {
     return false;
   }
   try {
-    await channel.permissionOverwrites.edit(userId, { SendMessages: value });
+    await channel.permissionOverwrites.edit(
+      targetId,
+      { SendMessages: value },
+      { type: OverwriteType.Member },
+    );
     return true;
   } catch (error) {
-    logger.warn('No se pudo actualizar permisos para el usuario', userId, error);
+    logger.warn('No se pudo actualizar permisos para el usuario', targetId, error);
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- ensure permission overwrites use normalized snowflake ids
- provide explicit overwrite type to allow locking when members are not cached

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3386e1e488326a5a2bb1a5d35f3f7