### PR TITLE
Normalize Discord snowflakes and improve review logging

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -36,6 +36,7 @@ export const CONFIG = {
   REVIEWS_CHANNEL_ID: process.env.REVIEWS_CHANNEL_ID ?? null,
   TRADE_LOGS_CHANNEL_ID: process.env.TRADE_LOGS_CHANNEL_ID ?? null,
   LOG_LEVEL: process.env.LOG_LEVEL ?? 'info',
+  LOG_FILE_PATH: process.env.LOG_FILE_PATH ?? 'dedosbot.log',
   DEDOS_GIF_PATH: deduceGifPath(),
   MYSQL: {
     HOST: process.env.MYSQL_HOST ?? 'localhost',

--- a/services/db.js
+++ b/services/db.js
@@ -14,6 +14,8 @@ export const pool = mysql.createPool({
   queueLimit: 0,
   timezone: 'Z',
   multipleStatements: false,
+  supportBigNumbers: true,
+  bigNumberStrings: true,
 });
 
 async function pingConnection() {

--- a/services/middlemen.repo.js
+++ b/services/middlemen.repo.js
@@ -1,27 +1,31 @@
 import { pool } from './db.js';
+import { normalizeSnowflake, normalizeSnowflakeArray } from '../utils/snowflake.js';
 
 export async function upsertMiddleman({ discordUserId, robloxUsername, robloxUserId = null }) {
+  const discordId = normalizeSnowflake(discordUserId, { label: 'discordUserId' });
   await pool.query(
     `INSERT INTO middlemen (discord_user_id, roblox_username, roblox_user_id)
      VALUES (?, ?, ?)
      ON DUPLICATE KEY UPDATE roblox_username = VALUES(roblox_username), roblox_user_id = VALUES(roblox_user_id), updated_at = CURRENT_TIMESTAMP`,
-    [discordUserId, robloxUsername, robloxUserId]
+    [discordId, robloxUsername, robloxUserId]
   );
 }
 
 export async function updateMiddleman({ discordUserId, robloxUsername, robloxUserId = null }) {
+  const discordId = normalizeSnowflake(discordUserId, { label: 'discordUserId' });
   await pool.query(
     `UPDATE middlemen
      SET roblox_username = COALESCE(?, roblox_username),
          roblox_user_id = COALESCE(?, roblox_user_id),
          updated_at = CURRENT_TIMESTAMP
      WHERE discord_user_id = ?`,
-    [robloxUsername ?? null, robloxUserId ?? null, discordUserId]
+    [robloxUsername ?? null, robloxUserId ?? null, discordId]
   );
 }
 
 export async function getMiddlemanByDiscordId(discordUserId) {
-  const [rows] = await pool.query('SELECT * FROM middlemen WHERE discord_user_id = ? LIMIT 1', [discordUserId]);
+  const discordId = normalizeSnowflake(discordUserId, { label: 'discordUserId' });
+  const [rows] = await pool.query('SELECT * FROM middlemen WHERE discord_user_id = ? LIMIT 1', [discordId]);
   return rows[0] ?? null;
 }
 
@@ -39,26 +43,32 @@ export async function listTopMiddlemen(limit = 10) {
 }
 
 export async function addMiddlemanRating(discordUserId, stars) {
+  const discordId = normalizeSnowflake(discordUserId, { label: 'discordUserId' });
   await pool.query(
     'UPDATE middlemen SET rating_sum = rating_sum + ?, rating_count = rating_count + 1 WHERE discord_user_id = ?',
-    [stars, discordUserId]
+    [stars, discordId]
   );
 }
 
 export async function incrementMiddlemanVouch(discordUserId) {
-  await pool.query('UPDATE middlemen SET vouches_count = vouches_count + 1 WHERE discord_user_id = ?', [discordUserId]);
+  const discordId = normalizeSnowflake(discordUserId, { label: 'discordUserId' });
+  await pool.query('UPDATE middlemen SET vouches_count = vouches_count + 1 WHERE discord_user_id = ?', [discordId]);
 }
 
 export async function getMiddlemenByDiscordIds(discordIds) {
   if (!Array.isArray(discordIds) || discordIds.length === 0) {
     return [];
   }
-  const placeholders = discordIds.map(() => '?').join(',');
+  const normalized = normalizeSnowflakeArray(discordIds, { label: 'discordUserId' });
+  if (normalized.length === 0) {
+    return [];
+  }
+  const placeholders = normalized.map(() => '?').join(',');
   const [rows] = await pool.query(
     `SELECT *, CASE WHEN rating_count > 0 THEN rating_sum / rating_count ELSE NULL END AS rating_avg
        FROM middlemen
        WHERE discord_user_id IN (${placeholders})`,
-    discordIds
+    normalized
   );
   return rows;
 }

--- a/services/migrations.js
+++ b/services/migrations.js
@@ -3,14 +3,14 @@ import { logger } from '../utils/logger.js';
 
 const MIGRATIONS = [
   `CREATE TABLE IF NOT EXISTS users (
-    id BIGINT PRIMARY KEY,
+    id VARCHAR(20) PRIMARY KEY,
     roblox_id BIGINT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
   ) ENGINE=InnoDB`,
   `CREATE TABLE IF NOT EXISTS warns (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    user_id BIGINT NOT NULL,
-    moderator_id BIGINT NULL,
+    user_id VARCHAR(20) NOT NULL,
+    moderator_id VARCHAR(20) NULL,
     reason TEXT,
     severity ENUM('minor','major','critical') DEFAULT 'minor',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -20,9 +20,9 @@ const MIGRATIONS = [
   ) ENGINE=InnoDB`,
   `CREATE TABLE IF NOT EXISTS tickets (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    guild_id BIGINT NOT NULL,
-    channel_id BIGINT NOT NULL,
-    owner_id BIGINT NOT NULL,
+    guild_id VARCHAR(20) NOT NULL,
+    channel_id VARCHAR(20) NOT NULL,
+    owner_id VARCHAR(20) NOT NULL,
     type ENUM('buy','sell','robux','nitro','decor','mm') NOT NULL,
     status ENUM('open','closed','pending') DEFAULT 'open',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -33,7 +33,7 @@ const MIGRATIONS = [
   ) ENGINE=InnoDB`,
   `CREATE TABLE IF NOT EXISTS ticket_participants (
     ticket_id INT NOT NULL,
-    user_id BIGINT NOT NULL,
+    user_id VARCHAR(20) NOT NULL,
     joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY(ticket_id, user_id),
     CONSTRAINT fk_tp_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
@@ -42,7 +42,7 @@ const MIGRATIONS = [
   `CREATE TABLE IF NOT EXISTS mm_trades (
     id INT AUTO_INCREMENT PRIMARY KEY,
     ticket_id INT NOT NULL,
-    user_id BIGINT NOT NULL,
+    user_id VARCHAR(20) NOT NULL,
     roblox_username VARCHAR(255) NOT NULL,
     roblox_user_id BIGINT NULL,
     items TEXT NOT NULL,
@@ -56,7 +56,7 @@ const MIGRATIONS = [
   ) ENGINE=InnoDB`,
   `CREATE TABLE IF NOT EXISTS middlemen (
     id INT AUTO_INCREMENT PRIMARY KEY,
-    discord_user_id BIGINT NOT NULL UNIQUE,
+    discord_user_id VARCHAR(20) NOT NULL UNIQUE,
     roblox_username VARCHAR(255) NOT NULL,
     roblox_user_id BIGINT NULL,
     vouches_count INT NOT NULL DEFAULT 0,
@@ -69,8 +69,8 @@ const MIGRATIONS = [
   `CREATE TABLE IF NOT EXISTS mm_reviews (
     id INT AUTO_INCREMENT PRIMARY KEY,
     ticket_id INT NOT NULL,
-    reviewer_user_id BIGINT NOT NULL,
-    middleman_user_id BIGINT NOT NULL,
+    reviewer_user_id VARCHAR(20) NOT NULL,
+    middleman_user_id VARCHAR(20) NOT NULL,
     stars TINYINT NOT NULL CHECK (stars BETWEEN 0 AND 5),
     review_text TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -81,7 +81,7 @@ const MIGRATIONS = [
   ) ENGINE=InnoDB`,
   `CREATE TABLE IF NOT EXISTS mm_claims (
     ticket_id INT PRIMARY KEY,
-    middleman_user_id BIGINT NOT NULL,
+    middleman_user_id VARCHAR(20) NOT NULL,
     claimed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     review_requested_at TIMESTAMP NULL,
     closed_at TIMESTAMP NULL,

--- a/services/mm.repo.js
+++ b/services/mm.repo.js
@@ -1,28 +1,40 @@
 import { pool } from './db.js';
+import { normalizeSnowflake } from '../utils/snowflake.js';
 
 export async function upsertTradeData({ ticketId, userId, robloxUsername, robloxUserId, items }) {
+  const discordId = normalizeSnowflake(userId, { label: 'tradeUserId' });
   await pool.query(
     `INSERT INTO mm_trades (ticket_id, user_id, roblox_username, roblox_user_id, items, confirmed)
      VALUES (?, ?, ?, ?, ?, 0)
      ON DUPLICATE KEY UPDATE roblox_username = VALUES(roblox_username), roblox_user_id = VALUES(roblox_user_id), items = VALUES(items), confirmed = 0, updated_at = CURRENT_TIMESTAMP`,
-    [ticketId, userId, robloxUsername, robloxUserId ?? null, items]
+    [ticketId, discordId, robloxUsername, robloxUserId ?? null, items]
   );
 }
 
 export async function setTradeConfirmed(ticketId, userId) {
-  await pool.query('UPDATE mm_trades SET confirmed = 1 WHERE ticket_id = ? AND user_id = ?', [ticketId, userId]);
+  const discordId = normalizeSnowflake(userId, { label: 'tradeUserId' });
+  await pool.query('UPDATE mm_trades SET confirmed = 1 WHERE ticket_id = ? AND user_id = ?', [ticketId, discordId]);
 }
 
 export async function resetTradeConfirmation(ticketId, userId) {
-  await pool.query('UPDATE mm_trades SET confirmed = 0 WHERE ticket_id = ? AND user_id = ?', [ticketId, userId]);
+  const discordId = normalizeSnowflake(userId, { label: 'tradeUserId' });
+  await pool.query('UPDATE mm_trades SET confirmed = 0 WHERE ticket_id = ? AND user_id = ?', [ticketId, discordId]);
 }
 
 export async function getTradesByTicket(ticketId) {
   const [rows] = await pool.query('SELECT * FROM mm_trades WHERE ticket_id = ?', [ticketId]);
-  return rows;
+  return rows.map((row) => ({
+    ...row,
+    user_id: normalizeSnowflake(row.user_id, { label: 'tradeUserId' }),
+  }));
 }
 
 export async function getTrade(ticketId, userId) {
-  const [rows] = await pool.query('SELECT * FROM mm_trades WHERE ticket_id = ? AND user_id = ? LIMIT 1', [ticketId, userId]);
-  return rows[0] ?? null;
+  const discordId = normalizeSnowflake(userId, { label: 'tradeUserId' });
+  const [rows] = await pool.query('SELECT * FROM mm_trades WHERE ticket_id = ? AND user_id = ? LIMIT 1', [ticketId, discordId]);
+  const trade = rows[0] ?? null;
+  if (trade) {
+    trade.user_id = normalizeSnowflake(trade.user_id, { label: 'tradeUserId' });
+  }
+  return trade;
 }

--- a/services/tickets.repo.js
+++ b/services/tickets.repo.js
@@ -1,9 +1,13 @@
 import { pool } from './db.js';
+import { normalizeSnowflake, normalizeSnowflakeArray } from '../utils/snowflake.js';
 
 export async function createTicket({ guildId, channelId, ownerId, type, status = 'open' }) {
+  const normalizedGuild = normalizeSnowflake(guildId, { label: 'guildId' });
+  const normalizedChannel = normalizeSnowflake(channelId, { label: 'channelId' });
+  const normalizedOwner = normalizeSnowflake(ownerId, { label: 'ownerId' });
   const [result] = await pool.query(
     'INSERT INTO tickets (guild_id, channel_id, owner_id, type, status) VALUES (?, ?, ?, ?, ?)',
-    [guildId, channelId, ownerId, type, status]
+    [normalizedGuild, normalizedChannel, normalizedOwner, type, status]
   );
   return result.insertId;
 }
@@ -17,19 +21,22 @@ export async function setTicketStatus(ticketId, status) {
 }
 
 export async function countOpenTicketsByUser(userId, type) {
+  const normalizedUser = normalizeSnowflake(userId, { label: 'ownerId' });
   const [rows] = await pool.query(
     'SELECT COUNT(*) as total FROM tickets WHERE owner_id = ? AND status = "open" AND type = ?',
-    [userId, type]
+    [normalizedUser, type]
   );
   return rows[0]?.total ?? 0;
 }
 
 export async function registerParticipant(ticketId, userId) {
-  await pool.query('INSERT IGNORE INTO ticket_participants (ticket_id, user_id) VALUES (?, ?)', [ticketId, userId]);
+  const normalizedUser = normalizeSnowflake(userId, { label: 'participantId' });
+  await pool.query('INSERT IGNORE INTO ticket_participants (ticket_id, user_id) VALUES (?, ?)', [ticketId, normalizedUser]);
 }
 
 export async function getTicketByChannel(channelId) {
-  const [rows] = await pool.query('SELECT * FROM tickets WHERE channel_id = ? LIMIT 1', [channelId]);
+  const normalizedChannel = normalizeSnowflake(channelId, { label: 'channelId' });
+  const [rows] = await pool.query('SELECT * FROM tickets WHERE channel_id = ? LIMIT 1', [normalizedChannel]);
   return rows[0] ?? null;
 }
 
@@ -40,5 +47,5 @@ export async function getTicket(ticketId) {
 
 export async function listParticipants(ticketId) {
   const [rows] = await pool.query('SELECT user_id FROM ticket_participants WHERE ticket_id = ?', [ticketId]);
-  return rows.map((row) => String(row.user_id));
+  return normalizeSnowflakeArray(rows.map((row) => row.user_id), { label: 'participantId' });
 }

--- a/services/users.repo.js
+++ b/services/users.repo.js
@@ -1,15 +1,19 @@
 import { pool } from './db.js';
+import { normalizeSnowflake } from '../utils/snowflake.js';
 
 export async function ensureUser(userId) {
-  await pool.query('INSERT IGNORE INTO users (id) VALUES (?)', [userId]);
-  return userId;
+  const normalized = normalizeSnowflake(userId, { label: 'userId' });
+  await pool.query('INSERT IGNORE INTO users (id) VALUES (?)', [normalized]);
+  return normalized;
 }
 
 export async function updateRobloxId(userId, robloxId) {
-  await pool.query('UPDATE users SET roblox_id = ? WHERE id = ?', [robloxId, userId]);
+  const normalized = normalizeSnowflake(userId, { label: 'userId' });
+  await pool.query('UPDATE users SET roblox_id = ? WHERE id = ?', [robloxId, normalized]);
 }
 
 export async function getUser(userId) {
-  const [rows] = await pool.query('SELECT * FROM users WHERE id = ?', [userId]);
+  const normalized = normalizeSnowflake(userId, { label: 'userId' });
+  const [rows] = await pool.query('SELECT * FROM users WHERE id = ?', [normalized]);
   return rows[0] ?? null;
 }

--- a/services/warns.repo.js
+++ b/services/warns.repo.js
@@ -1,17 +1,21 @@
 import { pool } from './db.js';
+import { normalizeSnowflake } from '../utils/snowflake.js';
 
 export async function addWarn({ userId, moderatorId, reason, severity }) {
+  const user = normalizeSnowflake(userId, { label: 'warnUserId' });
+  const moderator = moderatorId == null ? null : normalizeSnowflake(moderatorId, { label: 'moderatorId', allowEmpty: true });
   const [result] = await pool.query(
     'INSERT INTO warns (user_id, moderator_id, reason, severity) VALUES (?, ?, ?, ?)',
-    [userId, moderatorId, reason, severity ?? 'minor']
+    [user, moderator, reason, severity ?? 'minor']
   );
   return result.insertId;
 }
 
 export async function removeWarns(userId, amount) {
+  const user = normalizeSnowflake(userId, { label: 'warnUserId' });
   const [rows] = await pool.query(
     'SELECT id FROM warns WHERE user_id = ? ORDER BY created_at DESC LIMIT ?',
-    [userId, amount]
+    [user, amount]
   );
   if (rows.length === 0) return 0;
   const ids = rows.map((row) => row.id);
@@ -20,11 +24,20 @@ export async function removeWarns(userId, amount) {
 }
 
 export async function countWarns(userId) {
-  const [rows] = await pool.query('SELECT COUNT(*) as total FROM warns WHERE user_id = ?', [userId]);
+  const user = normalizeSnowflake(userId, { label: 'warnUserId' });
+  const [rows] = await pool.query('SELECT COUNT(*) as total FROM warns WHERE user_id = ?', [user]);
   return rows[0]?.total ?? 0;
 }
 
 export async function listWarns(userId) {
-  const [rows] = await pool.query('SELECT * FROM warns WHERE user_id = ? ORDER BY created_at DESC', [userId]);
-  return rows;
+  const user = normalizeSnowflake(userId, { label: 'warnUserId' });
+  const [rows] = await pool.query('SELECT * FROM warns WHERE user_id = ? ORDER BY created_at DESC', [user]);
+  return rows.map((row) => ({
+    ...row,
+    user_id: normalizeSnowflake(row.user_id, { label: 'warnUserId' }),
+    moderator_id:
+      row.moderator_id == null
+        ? null
+        : normalizeSnowflake(row.moderator_id, { label: 'moderatorId', allowEmpty: true }),
+  }));
 }

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -2,15 +2,15 @@
 -- Ejecuta estas sentencias en tu instancia MySQL antes de iniciar el bot si deseas crear las tablas manualmente.
 
 CREATE TABLE IF NOT EXISTS users (
-  id BIGINT PRIMARY KEY,
+  id VARCHAR(20) PRIMARY KEY,
   roblox_id BIGINT NULL,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
 CREATE TABLE IF NOT EXISTS warns (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  user_id BIGINT NOT NULL,
-  moderator_id BIGINT NULL,
+  user_id VARCHAR(20) NOT NULL,
+  moderator_id VARCHAR(20) NULL,
   reason TEXT,
   severity ENUM('minor','major','critical') DEFAULT 'minor',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -21,9 +21,9 @@ CREATE TABLE IF NOT EXISTS warns (
 
 CREATE TABLE IF NOT EXISTS tickets (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  guild_id BIGINT NOT NULL,
-  channel_id BIGINT NOT NULL,
-  owner_id BIGINT NOT NULL,
+  guild_id VARCHAR(20) NOT NULL,
+  channel_id VARCHAR(20) NOT NULL,
+  owner_id VARCHAR(20) NOT NULL,
   type ENUM('buy','sell','robux','nitro','decor','mm') NOT NULL,
   status ENUM('open','closed','pending') DEFAULT 'open',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS tickets (
 
 CREATE TABLE IF NOT EXISTS ticket_participants (
   ticket_id INT NOT NULL,
-  user_id BIGINT NOT NULL,
+  user_id VARCHAR(20) NOT NULL,
   joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (ticket_id, user_id),
   CONSTRAINT fk_tp_ticket FOREIGN KEY (ticket_id) REFERENCES tickets(id) ON DELETE CASCADE,
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS ticket_participants (
 CREATE TABLE IF NOT EXISTS mm_trades (
   id INT AUTO_INCREMENT PRIMARY KEY,
   ticket_id INT NOT NULL,
-  user_id BIGINT NOT NULL,
+  user_id VARCHAR(20) NOT NULL,
   roblox_username VARCHAR(255) NOT NULL,
   roblox_user_id BIGINT NULL,
   items TEXT NOT NULL,
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS mm_trades (
 
 CREATE TABLE IF NOT EXISTS middlemen (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  discord_user_id BIGINT NOT NULL UNIQUE,
+  discord_user_id VARCHAR(20) NOT NULL UNIQUE,
   roblox_username VARCHAR(255) NOT NULL,
   roblox_user_id BIGINT NULL,
   vouches_count INT NOT NULL DEFAULT 0,
@@ -74,8 +74,8 @@ CREATE TABLE IF NOT EXISTS middlemen (
 CREATE TABLE IF NOT EXISTS mm_reviews (
   id INT AUTO_INCREMENT PRIMARY KEY,
   ticket_id INT NOT NULL,
-  reviewer_user_id BIGINT NOT NULL,
-  middleman_user_id BIGINT NOT NULL,
+  reviewer_user_id VARCHAR(20) NOT NULL,
+  middleman_user_id VARCHAR(20) NOT NULL,
   stars TINYINT NOT NULL CHECK (stars BETWEEN 0 AND 5),
   review_text TEXT,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -87,7 +87,7 @@ CREATE TABLE IF NOT EXISTS mm_reviews (
 
 CREATE TABLE IF NOT EXISTS mm_claims (
   ticket_id INT PRIMARY KEY,
-  middleman_user_id BIGINT NOT NULL,
+  middleman_user_id VARCHAR(20) NOT NULL,
   claimed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   review_requested_at TIMESTAMP NULL,
   closed_at TIMESTAMP NULL,

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,12 +1,70 @@
+import { createWriteStream } from 'node:fs';
+import { resolve } from 'node:path';
 import { CONFIG } from '../config/config.js';
 
 const LEVELS = ['error', 'warn', 'info', 'debug'];
 const levelIndex = Math.max(0, LEVELS.indexOf(CONFIG.LOG_LEVEL));
 
+const logFilePath = CONFIG.LOG_FILE_PATH ? resolve(process.cwd(), CONFIG.LOG_FILE_PATH) : null;
+let fileStream = null;
+
+if (logFilePath) {
+  try {
+    fileStream = createWriteStream(logFilePath, { flags: 'a' });
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[LOGGER] No se pudo inicializar archivo de logs', error);
+  }
+}
+
+if (fileStream) {
+  process.on('exit', () => {
+    try {
+      fileStream?.end();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('[LOGGER] No se pudo cerrar archivo de logs', error);
+    }
+  });
+}
+
+function formatArg(arg) {
+  if (arg instanceof Error) {
+    const stack = arg.stack ? `\n${arg.stack}` : '';
+    return `${arg.name}: ${arg.message}${stack}`;
+  }
+  if (typeof arg === 'object' && arg !== null) {
+    try {
+      return JSON.stringify(arg);
+    } catch (error) {
+      return `[object error serializing: ${error.message}]`;
+    }
+  }
+  if (arg === undefined) {
+    return 'undefined';
+  }
+  return String(arg);
+}
+
+function appendToFile(level, prefix, args) {
+  if (!fileStream) {
+    return;
+  }
+  const formatted = args.map(formatArg).join(' ');
+  const line = `${new Date().toISOString()} ${prefix} ${formatted}`.trimEnd();
+  try {
+    fileStream.write(`${line}\n`);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[LOGGER] No se pudo escribir en archivo de logs', error);
+  }
+}
+
 const logAt = (targetLevel, prefix, args) => {
   if (LEVELS.indexOf(targetLevel) <= levelIndex) {
     // eslint-disable-next-line no-console
     console[targetLevel === 'debug' ? 'log' : targetLevel](prefix, ...args);
+    appendToFile(targetLevel, prefix, args);
   }
 };
 

--- a/utils/snowflake.js
+++ b/utils/snowflake.js
@@ -1,0 +1,42 @@
+import { logger } from './logger.js';
+
+const SNOWFLAKE_REGEX = /^\d{1,20}$/;
+
+function formatLabel(label) {
+  return label ?? 'snowflake';
+}
+
+export function normalizeSnowflake(value, { label, allowEmpty = false } = {}) {
+  if (value === null || value === undefined) {
+    if (allowEmpty) {
+      return null;
+    }
+    throw new TypeError(`Se requiere el ${formatLabel(label)}.`);
+  }
+  const text = String(value).trim();
+  if (!text && allowEmpty) {
+    return null;
+  }
+  if (!SNOWFLAKE_REGEX.test(text)) {
+    logger.warn('Snowflake inesperado para', formatLabel(label), text);
+  }
+  return text;
+}
+
+export function normalizeSnowflakeArray(values, options) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return [];
+  }
+  const unique = new Set();
+  for (const value of values) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+    try {
+      unique.add(normalizeSnowflake(value, options));
+    } catch (error) {
+      logger.warn('No se pudo normalizar snowflake', value, error.message);
+    }
+  }
+  return Array.from(unique);
+}


### PR DESCRIPTION
## Summary
- store Discord snowflakes as VARCHAR columns in the schema and runtime migrations
- introduce a reusable snowflake normalizer and apply it across data access layers to keep IDs as strings
- add file-based logging with richer review request audit messages and enable mysql big number support

## Testing
- Not run (requires external Discord/MySQL services)


------
https://chatgpt.com/codex/tasks/task_e_68d8516400648326b22f8c8a86d9e164