### PR TITLE
Handle missing Roblox avatar images when generating middleman cards

### DIFF
--- a/services/canvasCard.js
+++ b/services/canvasCard.js
@@ -83,6 +83,54 @@ function roundRect(ctx, x, y, w, h, r) {
   ctx.closePath();
 }
 
+function extractInitials(username) {
+  if (!username) {
+    return '?';
+  }
+  const normalized = String(username)
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .filter(Boolean);
+  if (normalized.length === 0) {
+    return '?';
+  }
+  if (normalized.length === 1) {
+    return normalized[0];
+  }
+  return normalized.join('');
+}
+
+function drawAvatarFallback(ctx, x, y, size, username) {
+  const gradient = ctx.createLinearGradient(x, y, x, y + size);
+  gradient.addColorStop(0, '#1C2338');
+  gradient.addColorStop(1, '#0F1423');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(x, y, size, size);
+
+  const overlay = ctx.createRadialGradient(
+    x + size * 0.5,
+    y + size * 0.5,
+    size * 0.1,
+    x + size * 0.5,
+    y + size * 0.5,
+    size * 0.65
+  );
+  overlay.addColorStop(0, 'rgba(0, 255, 168, 0.25)');
+  overlay.addColorStop(1, 'rgba(0, 0, 0, 0.05)');
+  ctx.fillStyle = overlay;
+  ctx.fillRect(x, y, size, size);
+
+  const initials = extractInitials(username);
+  ctx.fillStyle = '#00FFA8';
+  ctx.font = `bold ${Math.floor(size * 0.45)}px Arial`;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(initials, x + size / 2, y + size / 2);
+}
+
 function drawBlob(ctx, cx, cy, r, fill) {
   const g = ctx.createRadialGradient(cx, cy, r * 0.1, cx, cy, r);
   g.addColorStop(0, fill);
@@ -170,7 +218,7 @@ function resolveRatingLabel(rating, ratingCount) {
   return `Calificación: ${rating.toFixed(2)}`;
 }
 
-async function renderCard({ username, avatarUrl, rating, ratingCount, vouches }) {
+async function renderCard({ username, avatarUrl, fallbackAvatarUrl, rating, ratingCount, vouches }) {
   const canvas = createCanvas(CANVAS_W * SCALE, CANVAS_H * SCALE);
   const ctx = canvas.getContext('2d');
   ctx.scale(SCALE, SCALE);
@@ -218,7 +266,20 @@ async function renderCard({ username, avatarUrl, rating, ratingCount, vouches })
   const contentEndX = panel.x + panel.w - PADDING;
   const availableContentWidth = contentEndX - contentStartX;
 
-  const avatarImg = await loadImage(avatarUrl);
+  let avatarImg = null;
+  const attemptedSources = [avatarUrl, fallbackAvatarUrl].filter((value, index, array) => value && array.indexOf(value) === index);
+  for (let i = 0; i < attemptedSources.length; i += 1) {
+    const source = attemptedSources[i];
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      avatarImg = await loadImage(source);
+      break;
+    } catch (error) {
+      if (i === attemptedSources.length - 1) {
+        avatarImg = null;
+      }
+    }
+  }
 
   ctx.save();
   ctx.fillStyle = 'rgba(0,0,0,0.55)';
@@ -232,7 +293,11 @@ async function renderCard({ username, avatarUrl, rating, ratingCount, vouches })
   ctx.beginPath();
   ctx.arc(avatarX + avatarSize / 2, avatarY + avatarSize / 2, avatarSize / 2, 0, Math.PI * 2);
   ctx.clip();
-  ctx.drawImage(avatarImg, avatarX, avatarY, avatarSize, avatarSize);
+  if (avatarImg) {
+    ctx.drawImage(avatarImg, avatarX, avatarY, avatarSize, avatarSize);
+  } else {
+    drawAvatarFallback(ctx, avatarX, avatarY, avatarSize, username);
+  }
   ctx.restore();
 
   ctx.strokeStyle = '#00FFA8';
@@ -392,9 +457,11 @@ export async function generateForRobloxUser({ robloxUsername, robloxUserId, rati
     throw new Error('No se pudo resolver el usuario de Roblox para la tarjeta');
   }
   const info = await getRobloxInfo(resolvedUserId);
+  const fallbackAvatarUrl = `https://www.roblox.com/headshot-thumbnail/image?userId=${resolvedUserId}&width=352&height=352&format=png`;
   const card = await renderCard({
     username: info.username,
     avatarUrl: info.avatarUrl,
+    fallbackAvatarUrl,
     rating: clamp(Number.isFinite(rating) ? rating : 0, 0, 5),
     ratingCount: Number.isFinite(ratingCount) ? Math.max(0, ratingCount) : 0,
     vouches: Math.max(0, vouches ?? 0),


### PR DESCRIPTION
## Summary
- add graceful fallback when Roblox avatar images fail to load so middleman cards still render
- derive initials-based placeholder artwork to display when no avatar image is available
- attempt a secondary Roblox thumbnail URL before falling back to the placeholder

## Testing
- node -e "import('./services/canvasCard.js').then(() => console.log('loaded'));" *(fails: native dependency @napi-rs/canvas is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d87d52a4408326ac9cd42fedec2980