### PR TITLE
Trim partner input before resolving middleman member

### DIFF
--- a/features/middleman/logic.js
+++ b/features/middleman/logic.js
@@ -530,14 +530,18 @@ export async function handleMiddlemanMenu(interaction) {
 }
 
 function resolvePartnerMember(guild, input) {
-  const parsedId = parseUser(input);
+  const sanitized = input?.trim();
+  if (!sanitized) {
+    return null;
+  }
+  const parsedId = parseUser(sanitized);
   if (parsedId) {
     if (guild.members.cache.has(parsedId)) {
       return guild.members.cache.get(parsedId);
     }
     return guild.members.fetch(parsedId).catch(() => null);
   }
-  const normalized = input.toLowerCase();
+  const normalized = sanitized.toLowerCase();
   return guild.members.cache.find(
     (member) => member.user.username.toLowerCase() === normalized || member.displayName?.toLowerCase() === normalized
   );


### PR DESCRIPTION
## Summary
- trim the partner input value before trying to resolve the guild member
- avoid failing middleman creation when users add extra spaces in the partner field

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d880a94f188326a8aa3032054a3cb5